### PR TITLE
Add Codespaces setup for GROBID and parsing helper

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/devcontainers/python:3.11
+
+# Install Python dependencies at build time
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
+    && rm -rf /tmp/pip-tmp
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "GROBID Codespace",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  "workspaceFolder": "/workspace",
+  "forwardPorts": [8070, 8071],
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      }
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+
+services:
+  devcontainer:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: /bin/bash -c "while sleep 1000; do :; done"
+    depends_on:
+      - grobid
+
+  grobid:
+    image: grobid/grobid:0.8.2-crf
+    restart: unless-stopped
+    ports:
+      - "8070:8070"
+      - "8071:8071"

--- a/grobid_config.json
+++ b/grobid_config.json
@@ -1,0 +1,28 @@
+{
+  "grobid_server": "http://grobid:8070",
+  "batch_size": 10,
+  "sleep_time": 5,
+  "timeout": 180,
+  "coordinates": [
+    "title",
+    "persName",
+    "affiliation",
+    "orgName",
+    "formula",
+    "figure",
+    "ref",
+    "biblStruct",
+    "head",
+    "p",
+    "s",
+    "note"
+  ],
+  "logging": {
+    "level": "INFO",
+    "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    "console": true,
+    "file": null,
+    "max_file_size": "10MB",
+    "backup_count": 3
+  }
+}

--- a/parse_papers.py
+++ b/parse_papers.py
@@ -1,0 +1,89 @@
+"""Helpers for processing PDFs with GROBID inside JupyterLab.
+
+The module exposes :func:`process_pdfs` which relies on the Compose service
+name ``grobid`` defined in ``grobid_config.json``. Use it from notebooks to
+convert a directory of PDFs into TEI XML representations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+from grobid_client.grobid_client import GrobidClient
+
+
+TEI_SUFFIX = ".grobid.tei.xml"
+
+
+def process_pdfs(
+    input_dir: Path | str,
+    output_dir: Path | str = "tei-output",
+    concurrency: int = 2,
+    grobid_config: Path | str = "grobid_config.json",
+) -> List[Tuple[Path, Path]]:
+    """Run GROBID's ``processFulltextDocument`` service over local PDFs.
+
+    Parameters
+    ----------
+    input_dir:
+        Directory containing PDF files to parse.
+    output_dir:
+        Destination directory for the generated TEI XML.
+    concurrency:
+        Number of worker threads used by the client when dispatching requests.
+    grobid_config:
+        Path to the Grobid client JSON configuration file.
+    """
+
+    input_path = Path(input_dir)
+    if not input_path.is_dir():
+        raise NotADirectoryError(f"{input_path} is not a directory")
+
+    pdf_files = sorted(input_path.glob("*.pdf"))
+    if not pdf_files:
+        raise FileNotFoundError(f"No PDF files found in {input_path}")
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    client = GrobidClient(config_path=str(grobid_config))
+    client.process(
+        service="processFulltextDocument",
+        input_path=str(input_path),
+        output=str(output_path),
+        n=concurrency,
+        verbose=False,
+    )
+
+    results: List[Tuple[Path, Path]] = []
+    for pdf in pdf_files:
+        tei_file = output_path / (pdf.stem + TEI_SUFFIX)
+        results.append((pdf, tei_file))
+
+    return results
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Process PDFs with GROBID")
+    parser.add_argument("input", help="Directory containing PDF files")
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="tei-output",
+        help="Directory where TEI XML files will be written",
+    )
+    parser.add_argument(
+        "-n", "--concurrency", type=int, default=2, help="Number of worker threads"
+    )
+
+    args = parser.parse_args()
+
+    processed_files = process_pdfs(
+        args.input, output_dir=args.output, concurrency=args.concurrency
+    )
+
+    for pdf_file, tei_file in processed_files:
+        print(f"Processed {pdf_file} -> {tei_file}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.26.0
 requests>=2.32.0
 openpyxl>=3.1.2
 python-dateutil>=2.9.0
+grobid-client-python>=0.8.0


### PR DESCRIPTION
## Summary
- add a devcontainer and docker compose stack that launches the workspace alongside the grobid/grobid:0.8.2-crf service
- install Python requirements during image build so the official grobid client is available in the codespace
- provide a reusable helper script and configuration for calling GROBID from JupyterLab

## Testing
- python -m compileall parse_papers.py

------
https://chatgpt.com/codex/tasks/task_b_68d0155ce4cc8322800a6828c5190de6