### PR TITLE
Update devcontainer volume mount configuration

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
     volumes:
-      - ..:/workspace:cached
+      - ..:/workspace
     command: /bin/bash -c "while sleep 1000; do :; done"
     depends_on:
       - grobid


### PR DESCRIPTION
## Summary
- remove the cached flag from the devcontainer volume mount to avoid docker compose errors

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68d06302bd0c8322af232497cc5c9468