### PR TITLE
Add system build dependencies to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,15 @@
 # syntax=docker/dockerfile:1
 FROM mcr.microsoft.com/devcontainers/python:3.11
 
+# Install system dependencies required for Python packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libxml2-dev \
+        libxslt1-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install Python dependencies at build time
 COPY requirements.txt /tmp/pip-tmp/
 RUN pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt \


### PR DESCRIPTION
## Summary
- install build-essential, libxml2, libxslt, and zlib development libraries before Python requirements
- keep the image lean by clearing the apt cache

## Testing
- ⚠️ `docker build -f .devcontainer/Dockerfile -t slr-dev .` *(fails: docker CLI not available in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d0661d873c8322806f3b5ff8a3b917