### PR TITLE
Fix artifact collection directory handling

### DIFF
--- a/collect_papers.py
+++ b/collect_papers.py
@@ -18,12 +18,17 @@ def run(cmd):
         raise SystemExit(f"Command failed with code {e.returncode}: {' '.join(cmd)}")
 
 def collect_artifacts():
-    artifacts=[]
-    for d in ['raw','intermediate','converted']:
-        for root,_,files in os.walk(os.path.join(BASE,d)):
+    artifacts = []
+    for d in ["raw", "intermediate", "CSVs", "converted"]:
+        abs_dir = os.path.join(BASE, d)
+        if not os.path.isdir(abs_dir):
+            # Skip directories that are not produced in the current run (prevents FileNotFoundError).
+            continue
+        for root, _, files in os.walk(abs_dir):
             for fn in files:
-                artifacts.append(os.path.join(root,fn))
-    return artifacts
+                artifacts.append(os.path.join(root, fn))
+    # Sort to keep checksums.md deterministic regardless of filesystem traversal order.
+    return sorted(artifacts)
 
 def main():
     run([sys.executable,'s2ag_harvest_broad.py'])


### PR DESCRIPTION
## Summary
- handle optional CSV export directory when collecting artifacts for checksums
- skip absent directories during artifact collection to prevent crashes on fresh runs
- stabilize checksum output ordering for reproducible ledgers

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68d1da62246c8322a951868ed77f4e56