### PR TITLE
Add lxml dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy>=1.26.0
 requests>=2.32.0
 openpyxl>=3.1.2
 python-dateutil>=2.9.0
+lxml


### PR DESCRIPTION
## Summary
- add lxml to the Python requirements list so it is installed with other dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d1daa984708322817b4fb8e89156dd