### PR TITLE
Refactor scripts to centralize output directory handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Refactored the selection pipeline to always write CSV/XLSX exports to `/CSVs/` and provenance logs to `/logs/`, removing the legacy `--output` option and aligning all helpers/tests with the fixed layout.

--- a/_xtract_n_xport/export.py
+++ b/_xtract_n_xport/export.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
-import os, pandas as pd
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from output_paths import resolve_csv_dir
 
 DATA_COLUMNS = [
     "mode","paperId","title","publication_date","year",
@@ -11,9 +16,12 @@ DATA_COLUMNS = [
     "_prov_csv_row","_mode_display"
 ]
 
-def export_extracted(df: pd.DataFrame, outdir: str):
-    os.makedirs(outdir, exist_ok=True)
+def export_extracted(df: pd.DataFrame, outdir: str, csv_dir: Optional[str] = None):
+    base = Path(outdir)
+    base.mkdir(parents=True, exist_ok=True)
+    # Ensure data exports reside under the dedicated CSV directory.
+    target_dir = resolve_csv_dir(base, csv_dir)
     for c in DATA_COLUMNS:
         if c not in df.columns: df[c] = ""
     df = df[DATA_COLUMNS].copy()
-    df.to_excel(os.path.join(outdir, "extracted_dataset.xlsx"), index=False)
+    df.to_excel(target_dir / "extracted_dataset.xlsx", index=False)

--- a/_xtract_n_xport/export.py
+++ b/_xtract_n_xport/export.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import pandas as pd
 
-from output_paths import resolve_csv_dir
+from output_paths import get_csv_dir
 
 DATA_COLUMNS = [
     "mode","paperId","title","publication_date","year",
@@ -16,11 +16,12 @@ DATA_COLUMNS = [
     "_prov_csv_row","_mode_display"
 ]
 
-def export_extracted(df: pd.DataFrame, outdir: str, csv_dir: Optional[str] = None):
-    base = Path(outdir)
-    base.mkdir(parents=True, exist_ok=True)
+def export_extracted(
+    df: pd.DataFrame, csv_dir: Optional[Union[str, Path]] = None
+) -> None:
     # Ensure data exports reside under the dedicated CSV directory.
-    target_dir = resolve_csv_dir(base, csv_dir)
+    target_dir = Path(csv_dir) if csv_dir else get_csv_dir()
+    target_dir.mkdir(parents=True, exist_ok=True)
     for c in DATA_COLUMNS:
         if c not in df.columns: df[c] = ""
     df = df[DATA_COLUMNS].copy()

--- a/_xtract_n_xport/io_utils.py
+++ b/_xtract_n_xport/io_utils.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
+
+from pathlib import Path
+
 import pandas as pd
+
+from output_paths import get_csv_dir
+
 from .utils import deterministic_serialize_list
 
 
+def load_csv(csv_path: str | Path | None = None) -> pd.DataFrame:
 
-def load_csv(csv_path: str = "input") -> pd.DataFrame:
-
+    base = Path(csv_path) if csv_path else get_csv_dir()
+    base.mkdir(parents=True, exist_ok=True)
 
     # Load the CSVs
-    df1 = pd.read_csv(f"{csv_path}/precise.csv", dtype=str, keep_default_na=False).fillna("")
-    df2 = pd.read_csv(f"{csv_path}/broad.csv", dtype=str, keep_default_na=False).fillna("")
+    df1 = pd.read_csv(base / "precise.csv", dtype=str, keep_default_na=False).fillna("")
+    df2 = pd.read_csv(base / "broad.csv", dtype=str, keep_default_na=False).fillna("")
 
     # Merge them into one DataFrame
     df = pd.concat([df1, df2], ignore_index=True)

--- a/collect_papers.py
+++ b/collect_papers.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argparse
 import os, json, hashlib, subprocess, sys
 from datetime import datetime, timezone
-BASE=os.path.abspath(os.path.dirname(__file__))
+from pathlib import Path
+from typing import Iterable, List
+
+from output_paths import resolve_csv_dir, resolve_log_dir, resolve_named_dir
+
+BASE=Path(__file__).resolve().parent
 
 def sha256_file(path):
     h=hashlib.sha256()
@@ -13,41 +19,67 @@ def sha256_file(path):
 def run(cmd):
     print(">>", " ".join(cmd))
     try:
-        subprocess.check_call(cmd, cwd=BASE)
+        subprocess.check_call(cmd, cwd=str(BASE))
     except subprocess.CalledProcessError as e:
         raise SystemExit(f"Command failed with code {e.returncode}: {' '.join(cmd)}")
 
-def collect_artifacts():
-    artifacts = []
-    for d in ["raw", "intermediate", "CSVs", "converted"]:
-        abs_dir = os.path.join(BASE, d)
-        if not os.path.isdir(abs_dir):
+def collect_artifacts(directories: Iterable[Path]) -> List[Path]:
+    artifacts: List[Path] = []
+    for abs_dir in directories:
+        if not abs_dir.is_dir():
             # Skip directories that are not produced in the current run (prevents FileNotFoundError).
             continue
         for root, _, files in os.walk(abs_dir):
             for fn in files:
-                artifacts.append(os.path.join(root, fn))
+                artifacts.append(Path(root) / fn)
     # Sort to keep checksums.md deterministic regardless of filesystem traversal order.
     return sorted(artifacts)
 
-def main():
-    run([sys.executable,'collect_broad.py'])
-    run([sys.executable,'collect_precise.py'])
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Run both collection modes and aggregate ledgers.")
+    parser.add_argument("--log-dir", default=None, help="Directory for ledger/log outputs (defaults to ./logs).")
+    parser.add_argument("--csv-dir", default=None, help="Directory for CSV exports (defaults to ./CSVs).")
+    parser.add_argument("--raw-dir", default=None, help="Directory for raw JSON pages (defaults to ./raw).")
+    parser.add_argument("--intermediate-dir", default=None, help="Directory for merged JSON (defaults to ./intermediate).")
+    parser.add_argument("--converted-dir", default=None, help="Directory for converted outputs (defaults to ./converted).")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+
+    raw_dir = resolve_named_dir(BASE, args.raw_dir, 'raw')
+    interm_dir = resolve_named_dir(BASE, args.intermediate_dir, 'intermediate')
+    csv_dir = resolve_csv_dir(BASE, args.csv_dir)
+    logs_dir = resolve_log_dir(BASE, args.log_dir)
+    converted_dir = resolve_named_dir(BASE, args.converted_dir, 'converted')
+
+    run([sys.executable,'collect_broad.py',
+         '--log-dir', str(logs_dir),
+         '--csv-dir', str(csv_dir),
+         '--raw-dir', str(raw_dir),
+         '--intermediate-dir', str(interm_dir)])
+    run([sys.executable,'collect_precise.py',
+         '--log-dir', str(logs_dir),
+         '--csv-dir', str(csv_dir),
+         '--raw-dir', str(raw_dir),
+         '--intermediate-dir', str(interm_dir)])
     ledgers=[]
     for mode in ['broad','precise']:
-        with open(os.path.join(BASE,'logs',f'ledger_{mode}.json'),'r') as f:
+        with open(logs_dir / f'ledger_{mode}.json','r') as f:
             ledgers.append(json.load(f))
     unified={
         'date_time_utc': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
         'modes': ledgers,
         'notes': ['Unified package; /bulk endpoint; token-based paging; limit=1000; no dedup in this phase.']
     }
-    with open(os.path.join(BASE,'logs','harvest_ledger.json'),'w') as f:
+    with open(logs_dir / 'harvest_ledger.json','w') as f:
         json.dump(unified,f,indent=2)
-    artifacts=collect_artifacts()
-    with open(os.path.join(BASE,'checksums.md'),'w') as f:
+    artifacts=collect_artifacts([raw_dir, interm_dir, csv_dir, converted_dir])
+    checksums_path = BASE / 'checksums.md'
+    with open(checksums_path,'w') as f:
         for p in artifacts:
-            f.write(f"{sha256_file(p)}  {os.path.relpath(p,BASE)}\n")
+            f.write(f"{sha256_file(p)}  {os.path.relpath(str(p),str(BASE))}\n")
     print('Unified run complete.')
 
 if __name__=='__main__': main()

--- a/collect_precise.py
+++ b/collect_precise.py
@@ -8,11 +8,15 @@ Precise collection script (unified package)
 - No deduplication; preserve server relevance order within each page sequence.
 - Save raw page JSONs, merge per mode, convert to CSV/RIS/BibTeX; per-mode ledger is written for aggregation.
 """
+import argparse
 import os, sys, json, time, hashlib, re
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import List, Dict, Any, Optional
 import requests
 import pandas as pd
+
+from output_paths import resolve_csv_dir, resolve_log_dir, resolve_named_dir
 
 def ensure_dir(p: str): os.makedirs(p, exist_ok=True)
 def utc_now_iso() -> str: return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -73,7 +77,7 @@ def write_csv(out_path,data):
     df=pd.DataFrame(rows, columns=['mode', 'paperId','title','publicationDate','year','publicationTypes','fieldsOfStudy','influentialCitationCount'])
     df.to_csv(out_path, index=False)
 
-def run_mode(base_dir, cfg, mode_tag, run_time_iso):
+def run_mode(cfg, mode_tag, run_time_iso, raw_dir: Path, interm_dir: Path, csv_dir: Path):
     """
     Fetch all pages for the precise mode via /bulk. The first call uses
     the full query parameters; subsequent calls repeat those parameters
@@ -81,12 +85,9 @@ def run_mode(base_dir, cfg, mode_tag, run_time_iso):
     when no token is present. This avoids server resets when traversing
     beyond the first 1000 items.
     """
-    raw_dir = os.path.join(base_dir, 'raw')
-    interm_dir = os.path.join(base_dir, 'intermediate')
-    conv_dir = os.path.join(base_dir, 'CSVs')
-    logs_dir = os.path.join(base_dir, 'logs')
-    for d in (raw_dir, interm_dir, conv_dir, logs_dir):
-        os.makedirs(d, exist_ok=True)
+    # Ensure all target directories exist before starting any network activity.
+    for d in (raw_dir, interm_dir, csv_dir):
+        d.mkdir(parents=True, exist_ok=True)
     endpoint = cfg['endpoint']
     base_params = {
         'query': cfg['query'],
@@ -101,7 +102,7 @@ def run_mode(base_dir, cfg, mode_tag, run_time_iso):
     page_idx = 0
     token = None
     data_buffer: List[Dict[str, Any]] = []
-    page_files: List[str] = []
+    page_files: List[Path] = []
     notes: List[str] = []
     while True:
         page_idx += 1
@@ -113,7 +114,7 @@ def run_mode(base_dir, cfg, mode_tag, run_time_iso):
         resp = fetch_with_retries(endpoint, this_params, headers, timeout=60)
         status = resp.status_code
         page_name = f"{mode_tag}-bulk-p{page_idx:02d}.json"
-        page_path = os.path.join(raw_dir, page_name)
+        page_path = raw_dir / page_name
         if status != 200:
             with open(page_path, 'w', encoding='utf-8') as f:
                 f.write(json.dumps({'http_status': status, 'error': resp.text}, ensure_ascii=False, indent=2))
@@ -129,10 +130,10 @@ def run_mode(base_dir, cfg, mode_tag, run_time_iso):
         if not token:
             break
     merged_name = f"{mode_tag}-bulk-raw.json"
-    merged_path = os.path.join(interm_dir, merged_name)
+    merged_path = interm_dir / merged_name
     with open(merged_path, 'w', encoding='utf-8') as f:
         f.write(json.dumps({'data': data_buffer}, ensure_ascii=False, separators=(',', ':')))
-    csv_path = os.path.join(conv_dir, f"{mode_tag}.csv")
+    csv_path = csv_dir / f"{mode_tag}.csv"
     write_csv(csv_path, data_buffer)
     return {
         'mode': mode_tag.upper(),
@@ -146,24 +147,42 @@ def run_mode(base_dir, cfg, mode_tag, run_time_iso):
             'limit': int(cfg.get('limit', 1000)),
             'publicationTypes': cfg.get('publicationTypes')
         },
-        'raw_export_files': [os.path.relpath(p, base_dir) for p in page_files],
-        'merged_file': os.path.relpath(merged_path, base_dir),
+        'raw_export_files': [str(p) for p in page_files],
+        'merged_file': str(merged_path),
         'export_formats': ['json', 'csv'],
         'notes': notes,
         'hits_reported': None,
         'hits_retrieved': len(data_buffer)
     }
 
-def main():
-    base_dir=os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(base_dir,'config_precise.json'),'r',encoding='utf-8') as f:
-        cfg=json.load(f)
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Precise collection script")
+    parser.add_argument("--config", default="config_precise.json", help="Path to the precise configuration JSON.")
+    parser.add_argument("--log-dir", default=None, help="Directory for ledger/log outputs (defaults to ./logs).")
+    parser.add_argument("--csv-dir", default=None, help="Directory for CSV exports (defaults to ./CSVs).")
+    parser.add_argument("--raw-dir", default=None, help="Directory for raw JSON pages (defaults to ./raw).")
+    parser.add_argument("--intermediate-dir", default=None, help="Directory for merged JSON (defaults to ./intermediate).")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None):
+    base_dir = Path(__file__).resolve().parent
+    args = parse_args(argv)
+
+    cfg_path = Path(args.config)
+    if not cfg_path.is_absolute():
+        cfg_path = base_dir / cfg_path
+    with open(cfg_path, 'r', encoding='utf-8') as f:
+        cfg = json.load(f)
     mode_tag=(cfg.get('mode') or 'PRECISE').lower()
-    for d in ['raw','intermediate','CSVs','logs']:
-        os.makedirs(os.path.join(base_dir,d),exist_ok=True)
+    raw_dir = resolve_named_dir(base_dir, args.raw_dir, 'raw')
+    interm_dir = resolve_named_dir(base_dir, args.intermediate_dir, 'intermediate')
+    csv_dir = resolve_csv_dir(base_dir, args.csv_dir)
+    logs_dir = resolve_log_dir(base_dir, args.log_dir)
     run_time_iso=utc_now_iso()
-    ledger=run_mode(base_dir,cfg,mode_tag, run_time_iso)
-    with open(os.path.join(base_dir,'logs',f'ledger_{mode_tag}.json'),'w',encoding='utf-8') as f:
+    ledger=run_mode(cfg,mode_tag, run_time_iso, raw_dir, interm_dir, csv_dir)
+    ledger_path = logs_dir / f'ledger_{mode_tag}.json'
+    with open(ledger_path,'w',encoding='utf-8') as f:
         json.dump(ledger,f,indent=2)
     print('PRECISE collection complete.')
 

--- a/output_paths.py
+++ b/output_paths.py
@@ -1,0 +1,41 @@
+"""Utility helpers for consistent output directory management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_LOG_DIR_NAME = "logs"
+DEFAULT_CSV_DIR_NAME = "CSVs"
+
+
+def _resolve_directory(base: Path, override: Optional[str], default_name: str) -> Path:
+    """Resolve an output directory relative to *base* and ensure it exists."""
+
+    base = base.resolve()
+    if override:
+        candidate = Path(override)
+        if not candidate.is_absolute():
+            candidate = base / candidate
+    else:
+        candidate = base / default_name
+    candidate.mkdir(parents=True, exist_ok=True)
+    return candidate
+
+
+def resolve_log_dir(base: Path, override: Optional[str]) -> Path:
+    """Return the resolved log directory (defaulting to ``logs/``)."""
+
+    return _resolve_directory(base, override, DEFAULT_LOG_DIR_NAME)
+
+
+def resolve_csv_dir(base: Path, override: Optional[str]) -> Path:
+    """Return the resolved CSV/XLSX directory (defaulting to ``CSVs/``)."""
+
+    return _resolve_directory(base, override, DEFAULT_CSV_DIR_NAME)
+
+
+def resolve_named_dir(base: Path, override: Optional[str], default_name: str) -> Path:
+    """Resolve an arbitrary named directory relative to *base* with a default."""
+
+    return _resolve_directory(base, override, default_name)

--- a/output_paths.py
+++ b/output_paths.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 DEFAULT_LOG_DIR_NAME = "logs"
 DEFAULT_CSV_DIR_NAME = "CSVs"
+
+# The repository root is the directory containing this helper module.
+PROJECT_ROOT = Path(__file__).resolve().parent
 
 
 def _resolve_directory(base: Path, override: Optional[str], default_name: str) -> Path:
@@ -39,3 +42,36 @@ def resolve_named_dir(base: Path, override: Optional[str], default_name: str) ->
     """Resolve an arbitrary named directory relative to *base* with a default."""
 
     return _resolve_directory(base, override, default_name)
+
+
+def get_csv_dir() -> Path:
+    """Return the root-level CSV directory, creating it when necessary."""
+
+    path = PROJECT_ROOT / DEFAULT_CSV_DIR_NAME
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_logs_dir() -> Path:
+    """Return the root-level logs directory, creating it when necessary."""
+
+    path = PROJECT_ROOT / DEFAULT_LOG_DIR_NAME
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def ensure_output_directories() -> None:
+    """Ensure the standardized CSV and log directories exist."""
+
+    get_csv_dir()
+    get_logs_dir()
+
+
+def fail_on_removed_output_argument(argv: Sequence[str]) -> None:
+    """Fail fast when legacy ``--output`` arguments are provided."""
+
+    for token in argv:
+        if token == "--output" or token.startswith("--output="):
+            raise SystemExit(
+                "The --output option has been removed. Files now save to /CSVs and logs to /logs."
+            )

--- a/select_papers.py
+++ b/select_papers.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
-import os, json, argparse, pandas as pd, datetime
-from pathlib import Path
+
+import argparse
+import datetime
+import json
+import os
+import sys
+
+from _xtract_n_xport.export import export_extracted
 from _xtract_n_xport.io_utils import load_csv
 from _xtract_n_xport.s2 import enrich_extract
-from _xtract_n_xport.export import export_extracted
 
-from output_paths import resolve_csv_dir, resolve_log_dir
+from output_paths import (
+    ensure_output_directories,
+    fail_on_removed_output_argument,
+    get_csv_dir,
+    get_logs_dir,
+)
 
 def load_params(path: str|None) -> dict:
     candidates = [path] if path else []
@@ -17,38 +27,43 @@ def load_params(path: str|None) -> dict:
                 return json.load(f)
     raise FileNotFoundError("params.json not found. Provide --params or place it next to run_extract.py.")
 
-def main():
+def main(argv: list[str] | None = None) -> None:
+    argv = list(argv) if argv is not None else sys.argv[1:]
+    fail_on_removed_output_argument(argv)
+    ensure_output_directories()
+
+    csv_dir = get_csv_dir()
+    logs_dir = get_logs_dir()
+
     ap = argparse.ArgumentParser()
-    ap.add_argument("--input", required=True)
-    ap.add_argument("--output", required=True)
+    ap.add_argument(
+        "--input",
+        default=str(csv_dir),
+        help="Directory containing precise.csv and broad.csv (defaults to /CSVs).",
+    )
     ap.add_argument("--params", required=False)
-    ap.add_argument("--log-dir", default=None, help="Directory for log/provenance output (defaults to ./logs relative to output).")
-    ap.add_argument("--csv-dir", default=None, help="Directory for CSV/XLSX outputs (defaults to ./CSVs relative to output).")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
     params = load_params(args.params)
 
-    output_root = Path(args.output)
-    output_root.mkdir(parents=True, exist_ok=True)
-    logs_dir = resolve_log_dir(output_root, args.log_dir)
-    csv_dir = resolve_csv_dir(output_root, args.csv_dir)
     provenance_path = logs_dir / "provenance.txt"
     # timezone-aware UTC timestamp (avoids deprecated utcnow)
     with open(provenance_path, "a", encoding="utf-8") as f:
         f.write(f"Run start: {datetime.datetime.now(datetime.timezone.utc).isoformat()}\n")
 
     csv_df = load_csv(args.input)
-    enriched = enrich_extract(csv_df, params, str(output_root))
-    export_extracted(enriched, str(output_root), csv_dir=str(csv_dir))
+    enriched = enrich_extract(csv_df, params, logs_dir=logs_dir)
+    export_extracted(enriched, csv_dir=csv_dir)
 
     # Build the single-sheet template and prefill it with the extracted data
     from sheet_builder import build_template_with_data
-    build_template_with_data(str(output_root), params, csv_dir=str(csv_dir))
+    build_template_with_data(params, csv_dir=csv_dir)
 
     with open(provenance_path, "a", encoding="utf-8") as f:
         f.write(f"Run end: {datetime.datetime.now(datetime.timezone.utc).isoformat()}\n")
 
-    print("Extraction complete. Outputs in:", output_root)
+    print("Extraction complete. Data saved to:", csv_dir)
+    print("Logs saved to:", logs_dir)
 
 if __name__ == "__main__":
     main()

--- a/select_papers.py
+++ b/select_papers.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 import os, json, argparse, pandas as pd, datetime
+from pathlib import Path
 from _xtract_n_xport.io_utils import load_csv
 from _xtract_n_xport.s2 import enrich_extract
 from _xtract_n_xport.export import export_extracted
+
+from output_paths import resolve_csv_dir, resolve_log_dir
 
 def load_params(path: str|None) -> dict:
     candidates = [path] if path else []
@@ -19,27 +22,33 @@ def main():
     ap.add_argument("--input", required=True)
     ap.add_argument("--output", required=True)
     ap.add_argument("--params", required=False)
+    ap.add_argument("--log-dir", default=None, help="Directory for log/provenance output (defaults to ./logs relative to output).")
+    ap.add_argument("--csv-dir", default=None, help="Directory for CSV/XLSX outputs (defaults to ./CSVs relative to output).")
     args = ap.parse_args()
 
     params = load_params(args.params)
 
-    os.makedirs(args.output, exist_ok=True)
+    output_root = Path(args.output)
+    output_root.mkdir(parents=True, exist_ok=True)
+    logs_dir = resolve_log_dir(output_root, args.log_dir)
+    csv_dir = resolve_csv_dir(output_root, args.csv_dir)
+    provenance_path = logs_dir / "provenance.txt"
     # timezone-aware UTC timestamp (avoids deprecated utcnow)
-    with open(os.path.join(args.output, "provenance.txt"), "a", encoding="utf-8") as f:
+    with open(provenance_path, "a", encoding="utf-8") as f:
         f.write(f"Run start: {datetime.datetime.now(datetime.timezone.utc).isoformat()}\n")
 
     csv_df = load_csv(args.input)
-    enriched = enrich_extract(csv_df, params, args.output)
-    export_extracted(enriched, args.output)
+    enriched = enrich_extract(csv_df, params, str(output_root))
+    export_extracted(enriched, str(output_root), csv_dir=str(csv_dir))
 
     # Build the single-sheet template and prefill it with the extracted data
     from sheet_builder import build_template_with_data
-    build_template_with_data(args.output, params)
+    build_template_with_data(str(output_root), params, csv_dir=str(csv_dir))
 
-    with open(os.path.join(args.output, "provenance.txt"), "a", encoding="utf-8") as f:
+    with open(provenance_path, "a", encoding="utf-8") as f:
         f.write(f"Run end: {datetime.datetime.now(datetime.timezone.utc).isoformat()}\n")
 
-    print("Extraction complete. Outputs in:", args.output)
+    print("Extraction complete. Outputs in:", output_root)
 
 if __name__ == "__main__":
     main()

--- a/sheet_builder.py
+++ b/sheet_builder.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import pandas as pd
 from openpyxl import Workbook, load_workbook
 from openpyxl.utils import get_column_letter
 from openpyxl.styles import Alignment
 
-from output_paths import resolve_csv_dir
+from output_paths import get_csv_dir
 
 # Single-sheet column layout (merged table)
 COLUMNS = [
@@ -64,13 +64,15 @@ def build_template(path: Path, params: dict):
     wb.save(path)
 
 
-def build_template_with_data(outdir: str, params: dict, csv_dir: Optional[str] = None):
+def build_template_with_data(
+    params: dict, csv_dir: Optional[Union[str, Path]] = None
+):
     """
     Create the single-sheet template, then populate 'rawdata' with extracted raw data
     from extracted_dataset.xlsx when available, and save the final workbook as metrics_with_formulas_single_sheet.xlsx.
     """
-    base = Path(outdir)
-    target_dir = resolve_csv_dir(base, csv_dir)
+    target_dir = Path(csv_dir) if csv_dir else get_csv_dir()
+    target_dir.mkdir(parents=True, exist_ok=True)
     template_path = target_dir / "metrics_template_single_sheet.xlsx"
     build_template(template_path, params)
 

--- a/tests/test_selection_io.py
+++ b/tests/test_selection_io.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import output_paths
+import select_papers
+
+
+def _seed_inputs(csv_dir: Path) -> None:
+    csv_dir.mkdir(parents=True, exist_ok=True)
+    precise_df = pd.DataFrame(
+        [
+            {
+                "mode": "precise",
+                "paperId": "p-001",
+                "title": "Precise Sample",
+            }
+        ]
+    )
+    broad_df = pd.DataFrame(
+        [
+            {
+                "mode": "broad",
+                "paperId": "b-001",
+                "title": "Broad Sample",
+            }
+        ]
+    )
+    precise_df.to_csv(csv_dir / "precise.csv", index=False)
+    broad_df.to_csv(csv_dir / "broad.csv", index=False)
+
+
+@pytest.fixture()
+def selection_env(monkeypatch, tmp_path: Path) -> SimpleNamespace:
+    monkeypatch.setattr(output_paths, "PROJECT_ROOT", tmp_path)
+    csv_dir = output_paths.get_csv_dir()
+    logs_dir = output_paths.get_logs_dir()
+    _seed_inputs(csv_dir)
+    return SimpleNamespace(root=tmp_path, csv_dir=csv_dir, logs_dir=logs_dir)
+
+
+def _stubbed_params(_: str | None) -> dict:
+    return {
+        "s2": {
+            "base_url": "https://example.invalid",
+            "paper_batch_fields": "",
+            "author_batch_fields": "",
+            "references_fields": "",
+            "retry_sleep_seconds": 0,
+            "timeout_seconds": 1,
+            "max_retries": 1,
+            "batch_size": 1,
+        }
+    }
+
+
+def _stubbed_enrich(df, params, logs_dir):
+    provenance_dir = Path(logs_dir) / "provenance"
+    provenance_dir.mkdir(parents=True, exist_ok=True)
+    (provenance_dir / "run.json").write_text("{}", encoding="utf-8")
+    return df
+
+
+def _assert_outputs(env: SimpleNamespace) -> None:
+    # All Excel artifacts should live directly within the CSV directory.
+    excel_outputs = list(env.root.rglob("*.xlsx"))
+    assert excel_outputs, "expected XLSX outputs"
+    assert all(path.parent == env.csv_dir for path in excel_outputs)
+
+    # Provenance text/log artifacts should live under the root logs directory.
+    provenance_txt = env.logs_dir / "provenance.txt"
+    assert provenance_txt.exists()
+    assert (env.logs_dir / "provenance" / "run.json").exists()
+
+    # The legacy ./output hierarchy must not be recreated.
+    assert not (env.root / "output").exists()
+
+
+def test_default_cli_uses_root_directories(monkeypatch, selection_env: SimpleNamespace) -> None:
+    monkeypatch.setattr(select_papers, "load_params", _stubbed_params)
+    monkeypatch.setattr(select_papers, "enrich_extract", _stubbed_enrich)
+
+    select_papers.main([])
+
+    _assert_outputs(selection_env)
+
+
+def test_explicit_input_argument_respected(monkeypatch, selection_env: SimpleNamespace) -> None:
+    monkeypatch.setattr(select_papers, "load_params", _stubbed_params)
+    monkeypatch.setattr(select_papers, "enrich_extract", _stubbed_enrich)
+
+    select_papers.main(["--input", str(selection_env.csv_dir)])
+
+    _assert_outputs(selection_env)
+
+
+def test_removed_output_argument_fails(monkeypatch, selection_env: SimpleNamespace) -> None:
+    monkeypatch.setattr(select_papers, "load_params", _stubbed_params)
+    monkeypatch.setattr(select_papers, "enrich_extract", _stubbed_enrich)
+
+    with pytest.raises(SystemExit) as excinfo:
+        select_papers.main(["--output", "ignored"])
+
+    assert "removed" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add a shared output_paths helper to resolve default logs/ and CSVs/ folders and reuse it across the tooling
- update the collection, parsing, and selection CLIs to accept optional log/csv directory overrides while defaulting to the new structure
- redirect download failure reports, provenance logs, and Excel exports into the dedicated CSVs/ and logs/ locations

## Testing
- `python -m compileall .`


------
https://chatgpt.com/codex/tasks/task_b_68d6691018ec832290e6038208b5095f