### PR TITLE
Refactor collect_papers artifact collection to use unified raw directory

### DIFF
--- a/TESTS_EVALUATION.md
+++ b/TESTS_EVALUATION.md
@@ -1,0 +1,13 @@
+# Tests Directory Evaluation
+
+## Summary
+- Reviewed the repository history and current tree to determine whether a `/tests` directory or its submodules are present.
+- Confirmed that the project has no `/tests` directory in the current commit history (`git ls-tree -r HEAD --name-only | grep tests` returned no matches).
+- No code references, CI hooks, or imports rely on a `/tests` package, so no removal action is required.
+
+## Decision
+Because a `/tests` directory is absent and no components depend on it, no changes were made to remove tests. This preserves the repository's stability and avoids introducing unnecessary modifications.
+
+## Assumptions & Trade-offs
+- Assumes the authoritative branch is `work`, which currently lacks any `/tests` assets.
+- Removing non-existent directories would be a no-op; documenting the evaluation keeps the decision reproducible for future maintainers.

--- a/collect_papers.py
+++ b/collect_papers.py
@@ -19,7 +19,8 @@ def run(cmd):
 
 def collect_artifacts():
     artifacts = []
-    for d in ["raw", "intermediate", "CSVs", "converted"]:
+    # Data previously staged across /raw and /intermediate is now consolidated under /raw.
+    for d in ["raw", "CSVs", "converted"]:
         abs_dir = os.path.join(BASE, d)
         if not os.path.isdir(abs_dir):
             # Skip directories that are not produced in the current run (prevents FileNotFoundError).


### PR DESCRIPTION
## Summary
- update collect_papers to expect all staged data inside the root-level raw directory
- remove references to the deprecated intermediate directory while keeping artifact collection intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d6b5b73bc88322959cb4fcbada05cc