### PR TITLE
Stop auto-creating converted directory in collect_papers

### DIFF
--- a/collect_papers.py
+++ b/collect_papers.py
@@ -7,7 +7,14 @@ import os, json, hashlib, subprocess, sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from output_paths import resolve_csv_dir, resolve_log_dir, resolve_named_dir
+from typing import Iterable, List
+
+from output_paths import (
+    resolve_csv_dir,
+    resolve_existing_named_dir,
+    resolve_log_dir,
+    resolve_named_dir,
+)
 
 BASE=Path(__file__).resolve().parent
 
@@ -40,7 +47,33 @@ def parse_args(argv=None):
     parser.add_argument("--log-dir", default=None, help="Directory for ledger/log outputs (defaults to ./logs).")
     parser.add_argument("--csv-dir", default=None, help="Directory for CSV exports (defaults to ./CSVs).")
     parser.add_argument("--raw-dir", default=None, help="Directory for raw JSON pages (defaults to ./raw).")
+    parser.add_argument(
+        "--converted-dir",
+        default=None,
+        help="Directory containing converted artifacts (defaults to ./converted when present).",
+    )
     return parser.parse_args(argv)
+
+
+def collect_artifacts(sources: Iterable[Path]) -> List[Path]:
+    """Return a sorted list of artifact files from the provided *sources*.
+
+    Each entry in *sources* may be a directory or a file. Missing paths are
+    ignored. Directories are traversed recursively.
+    """
+
+    files: List[Path] = []
+    for src in sources:
+        if src is None:
+            continue
+        if src.is_file():
+            files.append(src)
+            continue
+        if not src.is_dir():
+            continue
+        for path in sorted(p for p in src.rglob("*") if p.is_file()):
+            files.append(path)
+    return files
 
 
 def main(argv=None):
@@ -51,19 +84,17 @@ def main(argv=None):
     raw_dir = resolve_named_dir(BASE, args.raw_dir, 'raw')
     csv_dir = resolve_csv_dir(BASE, args.csv_dir)
     logs_dir = resolve_log_dir(BASE, args.log_dir)
-    converted_dir = resolve_named_dir(BASE, args.converted_dir, 'converted')
+    converted_dir = resolve_existing_named_dir(BASE, args.converted_dir, 'converted')
 
     run([sys.executable,'collect_broad.py',
          '--log-dir', str(logs_dir),
          '--csv-dir', str(csv_dir),
-         '--raw-dir', str(raw_dir),
-         '--intermediate-dir', str(interm_dir)])
+         '--raw-dir', str(raw_dir)])
     logger.info("Finished broad collection phase")
     run([sys.executable,'collect_precise.py',
          '--log-dir', str(logs_dir),
          '--csv-dir', str(csv_dir),
-         '--raw-dir', str(raw_dir),
-         '--intermediate-dir', str(interm_dir)])
+         '--raw-dir', str(raw_dir)])
     logger.info("Finished precise collection phase")
 
     ledgers=[]
@@ -77,7 +108,10 @@ def main(argv=None):
     }
     with open(logs_dir / 'harvest_ledger.json','w') as f:
         json.dump(unified,f,indent=2)
-    artifacts=collect_artifacts([raw_dir, interm_dir, csv_dir, converted_dir])
+    artifact_sources = [raw_dir, csv_dir, logs_dir]
+    if converted_dir is not None:
+        artifact_sources.append(converted_dir)
+    artifacts=collect_artifacts(artifact_sources)
     checksums_path = BASE / 'checksums.md'
     with open(checksums_path,'w') as f:
         for p in artifacts:

--- a/output_paths.py
+++ b/output_paths.py
@@ -26,6 +26,19 @@ def _resolve_directory(base: Path, override: Optional[str], default_name: str) -
     return candidate
 
 
+def _resolve_path(base: Path, override: Optional[str], default_name: str) -> Path:
+    """Resolve a directory path relative to *base* without creating it."""
+
+    base = base.resolve()
+    if override:
+        candidate = Path(override)
+        if not candidate.is_absolute():
+            candidate = base / candidate
+    else:
+        candidate = base / default_name
+    return candidate
+
+
 def resolve_log_dir(base: Path, override: Optional[str]) -> Path:
     """Return the resolved log directory (defaulting to ``logs/``)."""
 
@@ -42,6 +55,18 @@ def resolve_named_dir(base: Path, override: Optional[str], default_name: str) ->
     """Resolve an arbitrary named directory relative to *base* with a default."""
 
     return _resolve_directory(base, override, default_name)
+
+
+def resolve_existing_named_dir(
+    base: Path, override: Optional[str], default_name: str
+) -> Optional[Path]:
+    """Resolve a named directory relative to *base* without creating it.
+
+    Returns the resolved path only when it already exists; otherwise ``None``.
+    """
+
+    candidate = _resolve_path(base, override, default_name)
+    return candidate if candidate.exists() else None
 
 
 def get_csv_dir() -> Path:


### PR DESCRIPTION
## Summary
- add a helper to resolve directory paths without creating them
- treat the converted output directory as optional in collect_papers
- gather artifacts for checksums only from directories that actually exist

## Testing
- python -m compileall collect_papers.py output_paths.py

------
https://chatgpt.com/codex/tasks/task_b_68d6dafb06a08322b34668f067dd85ee