### PR TITLE
Merge main into work — update Semantic Scholar configs and title-based PDF filenames

### DIFF
--- a/config_broad.json
+++ b/config_broad.json
@@ -3,8 +3,9 @@
   "mode": "BROAD",
   "limit": 1000,
   "fieldsOfStudy": "Computer Science",
-  "year": "2011-2025",
+  "year": "2022-2026",
   "fields": "paperId,title,publicationDate,publicationTypes,fieldsOfStudy,influentialCitationCount",
-  "query": "(\"intrusion detection\" | \"intrusion detection system*\" | IDS | \"network intrusion*\" | \"host-based intrusion*\" | HIDS | NIDS | \"intrusion prevention system*\" | IPS)",
+  "query": "(\"intrusion detection\" | \"intrusion detection system*\" | \"intrusion detection\"~2)",
+  "publicationTypes": "Review",
   "headers": {}
 }

--- a/config_precise.json
+++ b/config_precise.json
@@ -3,9 +3,9 @@
   "mode": "PRECISE",
   "limit": 1000,
   "fieldsOfStudy": "Computer Science",
-  "year": "2011-2025",
+  "year": "2022-2026",
   "fields": "paperId,title,publicationDate,publicationTypes,fieldsOfStudy,influentialCitationCount",
-  "query": "(\"intrusion detection\"~2 | \"intrusion detection system\") + (review | survey | \"systematic review\" | \"state of the art\" | taxonomy | overview)",
+  "query": "(\"intrusion detection\"~2 | \"intrusion detection system\" | IDS | \"network intrusion*\" | NIDS) + (review | mapping | survey | \"systematic review\" | \"state of the art\" | taxonomy | overview)",
   "publicationTypes": "Review",
   "headers": {}
 }

--- a/download_papers.py
+++ b/download_papers.py
@@ -210,6 +210,10 @@ def ensure_output_dir(path: str | Path) -> Path:
     return out
 
 
+def clean_name(s: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in s)
+
+
 def _is_probably_pdf(response: requests.Response, first_chunk: bytes | None) -> bool:
     """Try to determine if content is a PDF by header or content-type."""
     ctype = response.headers.get("Content-Type", "") or ""
@@ -509,15 +513,27 @@ def save_bytes_to_file(data: bytes, path: Path, paper_id: str, idx: int) -> bool
         return False
 
 
-def _download_task(idx: int, paper_id: str, url: str, out_dir: Path) -> Tuple[str, str, Optional[str]]:
+def _download_task(
+    idx: int,
+    paper_id: str,
+    url: str,
+    title: str | Path,
+    out_dir: Path | None = None,
+) -> Tuple[str, str, Optional[str]]:
     """
     Worker task executed in a thread:
     Returns (paper_identifier, url, None) on success or (paper_identifier, url, reason) on failure.
     """
+    if out_dir is None:
+        out_dir = Path(title)
+        title = ""
+    else:
+        title = str(title)
+
     identifier = paper_id if paper_id else f"<row-{idx}>"
     session = _create_requests_session()
     try:
-        out_path = out_dir / f"{paper_id}.pdf" if paper_id else out_dir / f"row-{idx}.pdf"
+        out_path = out_dir / (f"{clean_name(title)}.pdf" if title else f"{paper_id}.pdf" if paper_id else f"row-{idx}.pdf")
         if out_path.exists() and out_path.stat().st_size > 0:
             logging.info("[%s] Skipping (already exists) -> %s", identifier, out_path.name)
             return identifier, url, None
@@ -595,14 +611,16 @@ def download_papers(df: pd.DataFrame, output_dir: str | Path, workers: int = 1) 
             failures.append((identifier, url, "missing/invalid URL"))
             continue
 
-        tasks.append((idx, pid, url))
+        raw_title = row.get("title", "")
+        title = str(raw_title).strip() if pd.notna(raw_title) else ""
+        tasks.append((idx, pid, url, title))
 
     if not tasks:
         logging.info("No valid tasks to download.")
         return failures
 
     with ThreadPoolExecutor(max_workers=workers) as exe:
-        future_to_task = {exe.submit(_download_task, idx, pid, url, out_dir): (idx, pid, url) for idx, pid, url in tasks}
+        future_to_task = {exe.submit(_download_task, idx, pid, url, title, out_dir): (idx, pid, url) for idx, pid, url, title in tasks}
         for future in as_completed(future_to_task):
             idx, pid, url = future_to_task[future]
             identifier = pid if pid else f"<row-{idx}>"


### PR DESCRIPTION
### Motivation
- Bring `codex` up to date with recent `main` changes including updated Semantic Scholar query windows and filters.
- Allow downloaded PDFs to be named by paper title when available for more informative filenames.
- Preserve existing downloader API compatibility so callers and tests remain functional.

### Description
- Updated `config_broad.json` and `config_precise.json` to use the 2022–2026 year window and refined query strings, and added `publicationTypes: "Review"` where applicable.
- Added `clean_name()` to sanitize titles and used title-based file naming in `download_papers.py` when a title is present.
- Changed `_download_task` signature to accept a `title` and made `out_dir` optional to preserve existing call sites, and updated `download_papers()` to include `title` in tasks.
- Kept backward compatibility by accepting `out_dir=None` in `_download_task`, which preserves the original calling behavior and test expectations.

### Testing
- Ran `python -m pytest` after the initial merge which showed one failing test due to the `_download_task` signature mismatch.
- Modified `_download_task` to accept an optional `out_dir` and re-ran `python -m pytest`, after which all tests passed.
- Final test result: `4 passed` for the test suite executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3f014235848330ab175a80c84e8389)