### PR TITLE
Preprocess paper CSV inputs by citation count

### DIFF
--- a/_xtract_n_xport/io_utils.py
+++ b/_xtract_n_xport/io_utils.py
@@ -9,14 +9,62 @@ from output_paths import get_csv_dir
 from .utils import deterministic_serialize_list
 
 
+INFLUENTIAL_CITATION_COUNT_COLUMN = "influentialCitationCount"
+DEFAULT_PREPROCESS_LIMIT = 300
+
+
+def trim_by_influential_citation_count(
+    df: pd.DataFrame,
+    *,
+    limit: int = DEFAULT_PREPROCESS_LIMIT,
+) -> pd.DataFrame:
+    """Sort by influential citations and retain the top rows, including ties.
+
+    The cutoff is the influential citation count at the requested limit after a
+    descending numeric sort. All rows with that same cutoff value are retained so
+    ties are not split across the trim boundary.
+    """
+    if limit < 1:
+        raise ValueError("limit must be at least 1")
+    if INFLUENTIAL_CITATION_COUNT_COLUMN not in df.columns:
+        raise KeyError(f"Missing required column: {INFLUENTIAL_CITATION_COUNT_COLUMN}")
+    if df.empty:
+        return df.copy()
+
+    result = df.copy()
+    citation_counts = pd.to_numeric(
+        result[INFLUENTIAL_CITATION_COUNT_COLUMN],
+        errors="raise",
+        downcast="integer",
+    )
+    result = result.assign(_influential_citation_count_sort=citation_counts)
+    result = result.sort_values(
+        by="_influential_citation_count_sort",
+        ascending=False,
+        kind="mergesort",
+    )
+
+    if len(result) > limit:
+        cutoff = result.iloc[limit - 1]["_influential_citation_count_sort"]
+        result = result[result["_influential_citation_count_sort"] >= cutoff]
+
+    return result.drop(columns=["_influential_citation_count_sort"]).reset_index(drop=True)
+
+
+def _read_and_preprocess_input_csv(path: Path) -> pd.DataFrame:
+    df = pd.read_csv(path, dtype=str, keep_default_na=False).fillna("")
+    return trim_by_influential_citation_count(df)
+
+
 def load_csv(csv_path: str | Path | None = None) -> pd.DataFrame:
 
     base = Path(csv_path) if csv_path else get_csv_dir()
     base.mkdir(parents=True, exist_ok=True)
 
-    # Load the CSVs
-    df1 = pd.read_csv(base / "precise.csv", dtype=str, keep_default_na=False).fillna("")
-    df2 = pd.read_csv(base / "broad.csv", dtype=str, keep_default_na=False).fillna("")
+    # Load, numerically sort, and trim each CSV before merging them. Ties at the
+    # 300-row boundary are kept so equal influential citation counts stay intact.
+    df1 = _read_and_preprocess_input_csv(base / "precise.csv")
+    df2 = _read_and_preprocess_input_csv(base / "broad.csv")
 
     # Merge them into one DataFrame
     df = pd.concat([df1, df2], ignore_index=True)

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from _xtract_n_xport.io_utils import load_csv, trim_by_influential_citation_count
+
+
+def test_trim_by_influential_citation_count_sorts_descending_and_keeps_boundary_ties():
+    df = pd.DataFrame(
+        [
+            {"paperId": "low", "influentialCitationCount": "1"},
+            *(
+                {"paperId": f"high-{i}", "influentialCitationCount": "10"}
+                for i in range(299)
+            ),
+            {"paperId": "tie-a", "influentialCitationCount": "5"},
+            {"paperId": "tie-b", "influentialCitationCount": "5"},
+        ]
+    )
+
+    trimmed = trim_by_influential_citation_count(df, limit=300)
+
+    assert len(trimmed) == 301
+    assert trimmed["paperId"].tolist()[:299] == [f"high-{i}" for i in range(299)]
+    assert trimmed["paperId"].tolist()[299:] == ["tie-a", "tie-b"]
+    assert "low" not in trimmed["paperId"].tolist()
+
+
+def test_trim_by_influential_citation_count_uses_numeric_sorting():
+    df = pd.DataFrame(
+        [
+            {"paperId": "two", "influentialCitationCount": "2"},
+            {"paperId": "ten", "influentialCitationCount": "10"},
+            {"paperId": "one", "influentialCitationCount": "1"},
+        ]
+    )
+
+    trimmed = trim_by_influential_citation_count(df, limit=2)
+
+    assert trimmed["paperId"].tolist() == ["ten", "two"]
+
+
+def test_trim_by_influential_citation_count_rejects_non_numeric_values():
+    df = pd.DataFrame([{"paperId": "bad", "influentialCitationCount": "not-a-number"}])
+
+    with pytest.raises(ValueError):
+        trim_by_influential_citation_count(df)
+
+
+def test_load_csv_preprocesses_precise_and_broad_independently(tmp_path):
+    precise = pd.DataFrame(
+        [
+            {"paperId": f"p{i}", "influentialCitationCount": str(i)}
+            for i in range(305)
+        ]
+    )
+    broad = pd.DataFrame(
+        [
+            {"paperId": f"b{i}", "influentialCitationCount": str(i)}
+            for i in range(305)
+        ]
+    )
+    precise.to_csv(tmp_path / "precise.csv", index=False)
+    broad.to_csv(tmp_path / "broad.csv", index=False)
+
+    loaded = load_csv(tmp_path)
+
+    assert len(loaded) == 600
+    assert loaded["paperId"].tolist()[:3] == ["p304", "p303", "p302"]
+    assert loaded["paperId"].tolist()[300:303] == ["b304", "b303", "b302"]
+    assert "p4" not in loaded["paperId"].tolist()
+    assert "b4" not in loaded["paperId"].tolist()
+    assert "influential_citation_count" in loaded.columns


### PR DESCRIPTION
### Motivation
- Ensure `precise.csv` and `broad.csv` are ranked by the numeric value of `influentialCitationCount` so selection is deterministic and correct.
- Trim inputs to the top ~300 rows while never splitting ties at the cutoff so identical citation counts are preserved.

### Description
- Add `trim_by_influential_citation_count` in `_xtract_n_xport/io_utils.py` which converts `influentialCitationCount` to numeric, sorts descending (stable `mergesort`), determines the cutoff at the requested `limit`, and retains all rows with the cutoff value. 
- Add helper `_read_and_preprocess_input_csv` and call it from `load_csv` so `precise.csv` and `broad.csv` are preprocessed independently before being concatenated. 
- Preserve existing canonicalization of columns and downstream behavior while adding constants `INFLUENTIAL_CITATION_COUNT_COLUMN` and `DEFAULT_PREPROCESS_LIMIT` for clarity. 
- Add unit tests in `tests/test_io_utils.py` covering tie retention at the boundary, numeric sorting, rejection of non-numeric values, and independent preprocessing of both CSV files.

### Testing
- Ran `pytest -q tests/test_io_utils.py` and all tests passed (`4 passed`).
- Ran `python -m py_compile select_papers.py _xtract_n_xport/io_utils.py` which succeeded with no syntax errors. 
- Ran full `pytest -q` which failed due to an existing unrelated test (`tests/test_download_papers.py::test_download_task_httpx_fallback`) expecting a different `_download_task` signature, not caused by these IO changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3f216f59dc833089b993cac9b90280)