### PR TITLE
Support Semantic Scholar API key via env var and inject `x-api-key` header

### DIFF
--- a/_xtract_n_xport/s2.py
+++ b/_xtract_n_xport/s2.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import os
 import re
 import time
 from pathlib import Path
@@ -16,11 +17,17 @@ from output_paths import get_logs_dir
 from .utils import deterministic_json, normalize_doi
 
 
+SEMANTIC_SCHOLAR_API_KEY_ENV = 'SEMANTIC_SCHOLAR_API_KEY'
+
+
 class S2Client:
     def __init__(self, params: dict, logs_dir: Optional[Path] = None):
         self.base = params["s2"]["base_url"].rstrip("/")
         self.params = params
         self.session = requests.Session()
+        api_key = os.environ.get(SEMANTIC_SCHOLAR_API_KEY_ENV)
+        if api_key:
+            self.session.headers.update({'x-api-key': api_key})
         self.logs_dir = Path(logs_dir) if logs_dir else get_logs_dir()
         self.provenance_root = self.logs_dir / "provenance"
         self.provenance_root.mkdir(parents=True, exist_ok=True)

--- a/collect.py
+++ b/collect.py
@@ -10,6 +10,7 @@ aggregate harvest ledger. A single mode can be selected with, for example:
 import argparse
 import json
 import logging
+import os
 import re
 import time
 from datetime import datetime, timezone
@@ -32,6 +33,7 @@ DEFAULT_CONFIGS = {
 }
 
 logger = logging.getLogger(__name__)
+SEMANTIC_SCHOLAR_API_KEY_ENV = 'SEMANTIC_SCHOLAR_API_KEY'
 
 
 def configure_logging() -> None:
@@ -52,6 +54,15 @@ def parse_retry_after(value: Optional[str]) -> Optional[float]:
         return float(value.strip())
     except ValueError:
         return None
+
+
+def semantic_scholar_headers(headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    api_key = os.environ.get(SEMANTIC_SCHOLAR_API_KEY_ENV)
+    if not api_key:
+        return headers or {}
+    request_headers = dict(headers or {})
+    request_headers['x-api-key'] = api_key
+    return request_headers
 
 
 def fetch_with_retries(endpoint: str, params: Dict[str, Any], headers: Dict[str, str], timeout: int = 60):
@@ -139,7 +150,7 @@ def run_mode(cfg: Dict[str, Any], mode_tag: str, run_time_iso: str, raw_dir: Pat
         if token:
             params['token'] = token
 
-        response = fetch_with_retries(cfg['endpoint'], params, cfg.get('headers') or {}, timeout=60)
+        response = fetch_with_retries(cfg['endpoint'], params, semantic_scholar_headers(cfg.get('headers')), timeout=60)
         page_path = raw_dir / f'{mode_tag}-bulk-p{page_idx:02d}.json'
         page_files.append(page_path)
 


### PR DESCRIPTION
### Motivation
- Allow authenticated requests to Semantic Scholar by reading an API key from the environment and attaching it to HTTP requests to avoid rate limits or access restrictions.
- Ensure both the higher-level collection script and the S2 client use the same env-driven header so bulk and client requests behave consistently.

### Description
- Added `SEMANTIC_SCHOLAR_API_KEY_ENV` and an `os` import to `_xtract_n_xport/s2.py`, and set the session header `x-api-key` from the environment when present. 
- Added `semantic_scholar_headers` and an `os` import to `collect.py` to construct request headers that include `x-api-key` when `SEMANTIC_SCHOLAR_API_KEY_ENV` is set. 
- Updated the call to `fetch_with_retries` in `collect.py` to pass `semantic_scholar_headers(cfg.get('headers'))` so bulk fetches include the API key if available.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3f1c04e6748330a8a986a02e00e18f)