### PR TITLE
Add regression tests for collect.py alias and Semantic Scholar pagination

### DIFF
--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,0 +1,116 @@
+import json
+import runpy
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pandas as pd
+
+import collect
+from slr_meta.collection import semantic_scholar
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200, text=""):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+
+def test_collect_import_alias_exposes_collection_module():
+    assert collect is semantic_scholar
+    assert callable(collect.main)
+
+
+def test_collect_script_entrypoint_invokes_main(monkeypatch):
+    called = []
+
+    def fake_main():
+        called.append(True)
+
+    monkeypatch.setattr(semantic_scholar, "main", fake_main)
+    runpy.run_path("collect.py", run_name="__main__")
+
+    assert called == [True]
+
+
+def test_run_mode_fetches_token_pages_and_writes_outputs(tmp_path, monkeypatch):
+    responses = [
+        FakeResponse(
+            {
+                "data": [
+                    {
+                        "paperId": "p1",
+                        "title": "First",
+                        "publicationDate": "2024-03-01",
+                        "publicationTypes": ["Review"],
+                        "fieldsOfStudy": ["Computer Science"],
+                        "influentialCitationCount": 5,
+                    }
+                ],
+                "token": "next",
+            }
+        ),
+        FakeResponse(
+            {
+                "data": [
+                    {
+                        "paperId": "p2",
+                        "title": "Second",
+                        "publicationDate": "2025",
+                        "publicationTypes": None,
+                        "fieldsOfStudy": ["Computer Science"],
+                        "influentialCitationCount": 2,
+                    }
+                ]
+            }
+        ),
+    ]
+    captured_params = []
+
+    def fake_fetch(endpoint, params, headers, timeout=60):
+        captured_params.append(dict(params))
+        return responses.pop(0)
+
+    monkeypatch.setattr(semantic_scholar, "fetch_with_retries", fake_fetch)
+
+    cfg = {
+        "endpoint": "https://example.test/bulk",
+        "query": "intrusion detection",
+        "year": "2022-2026",
+        "fieldsOfStudy": "Computer Science",
+        "fields": "paperId,title,publicationDate",
+        "limit": 1000,
+        "publicationTypes": "Review",
+        "headers": {},
+    }
+
+    ledger = semantic_scholar.run_mode(
+        cfg,
+        "broad",
+        "2026-06-30T00:00:00Z",
+        tmp_path / "raw",
+        tmp_path / "csv",
+    )
+
+    assert captured_params[0]["query"] == "intrusion detection"
+    assert "token" not in captured_params[0]
+    assert captured_params[1]["token"] == "next"
+    assert ledger["hits_retrieved"] == 2
+    assert ledger["notes"] == []
+
+    merged = json.loads(
+        (tmp_path / "raw" / "broad-bulk-raw.json").read_text(encoding="utf-8")
+    )
+    assert [record["paperId"] for record in merged["data"]] == ["p1", "p2"]
+
+    csv = pd.read_csv(tmp_path / "csv" / "broad.csv")
+    assert csv["mode"].tolist() == ["BROAD", "BROAD"]
+    assert csv["year"].tolist() == [2024, 2025]


### PR DESCRIPTION
### Motivation
- Prevent regressions in the `collect.py` compatibility alias and ensure the script entrypoint still invokes the collection `main()` function.
- Verify `run_mode` handles token-based pagination and correctly writes merged JSON and CSV outputs.
- Provide automated coverage to detect future breakage of query/token propagation and year parsing logic.

### Description
- Add `tests/test_collect.py` which ensures the top-level `collect` import is an alias for `slr_meta.collection.semantic_scholar` and that `collect.main` is callable.
- Add a test that runs the script entrypoint via `runpy.run_path("collect.py", run_name="__main__")` and asserts it calls `main()`.
- Add a mocked token-pagination test for `run_mode` that stubs `fetch_with_retries`, asserts token propagation in requests, validates `ledger["hits_retrieved"]` and `ledger["notes"]`, and checks the merged JSON and CSV outputs (including parsed `year`).
- Ensure the test file adjusts `sys.path` to import the project modules reliably by inserting the repository root.

### Testing
- Ran the new tests with `pytest -q tests/test_collect.py` which passed for the new file.
- Ran the full suite with `pytest -q` after adding the tests, resulting in `11 passed` and no failures.
- All automated tests succeeded (no test failures were introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a442f3fbc748330a7dc20479c56b0e0)