### PR TITLE
Use stdlib CSV writer instead of pandas and add tests for collect script

### DIFF
--- a/slr_meta/collection/semantic_scholar.py
+++ b/slr_meta/collection/semantic_scholar.py
@@ -8,6 +8,7 @@ aggregate harvest ledger. A single mode can be selected with, for example:
     python collect.py --mode broad
 """
 import argparse
+import csv
 import json
 import logging
 import os
@@ -17,7 +18,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import pandas as pd
 import requests
 
 from slr_meta.shared.paths import PROJECT_ROOT, resolve_csv_dir, resolve_log_dir, resolve_named_dir
@@ -110,7 +110,10 @@ def to_csv_rows(data: List[Dict[str, Any]], mode_tag: str) -> List[Dict[str, Any
 
 
 def write_csv(out_path: Path, data: List[Dict[str, Any]], mode_tag: str) -> None:
-    pd.DataFrame(to_csv_rows(data, mode_tag), columns=CSV_COLUMNS).to_csv(out_path, index=False)
+    with open(out_path, 'w', encoding='utf-8', newline='') as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerows(to_csv_rows(data, mode_tag))
 
 
 def load_config(config_path: Path) -> Dict[str, Any]:

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,0 +1,117 @@
+import json
+import runpy
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import csv
+
+import collect
+from slr_meta.collection import semantic_scholar
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200, text=""):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+
+def test_collect_import_alias_exposes_collection_module():
+    assert collect is semantic_scholar
+    assert callable(collect.main)
+
+
+def test_collect_script_entrypoint_invokes_main(monkeypatch):
+    called = []
+
+    def fake_main():
+        called.append(True)
+
+    monkeypatch.setattr(semantic_scholar, "main", fake_main)
+    runpy.run_path("collect.py", run_name="__main__")
+
+    assert called == [True]
+
+
+def test_run_mode_fetches_token_pages_and_writes_outputs(tmp_path, monkeypatch):
+    responses = [
+        FakeResponse(
+            {
+                "data": [
+                    {
+                        "paperId": "p1",
+                        "title": "First",
+                        "publicationDate": "2024-03-01",
+                        "publicationTypes": ["Review"],
+                        "fieldsOfStudy": ["Computer Science"],
+                        "influentialCitationCount": 5,
+                    }
+                ],
+                "token": "next",
+            }
+        ),
+        FakeResponse(
+            {
+                "data": [
+                    {
+                        "paperId": "p2",
+                        "title": "Second",
+                        "publicationDate": "2025",
+                        "publicationTypes": None,
+                        "fieldsOfStudy": ["Computer Science"],
+                        "influentialCitationCount": 2,
+                    }
+                ]
+            }
+        ),
+    ]
+    captured_params = []
+
+    def fake_fetch(endpoint, params, headers, timeout=60):
+        captured_params.append(dict(params))
+        return responses.pop(0)
+
+    monkeypatch.setattr(semantic_scholar, "fetch_with_retries", fake_fetch)
+
+    cfg = {
+        "endpoint": "https://example.test/bulk",
+        "query": "intrusion detection",
+        "year": "2022-2026",
+        "fieldsOfStudy": "Computer Science",
+        "fields": "paperId,title,publicationDate",
+        "limit": 1000,
+        "publicationTypes": "Review",
+        "headers": {},
+    }
+
+    ledger = semantic_scholar.run_mode(
+        cfg,
+        "broad",
+        "2026-06-30T00:00:00Z",
+        tmp_path / "raw",
+        tmp_path / "csv",
+    )
+
+    assert captured_params[0]["query"] == "intrusion detection"
+    assert "token" not in captured_params[0]
+    assert captured_params[1]["token"] == "next"
+    assert ledger["hits_retrieved"] == 2
+    assert ledger["notes"] == []
+
+    merged = json.loads(
+        (tmp_path / "raw" / "broad-bulk-raw.json").read_text(encoding="utf-8")
+    )
+    assert [record["paperId"] for record in merged["data"]] == ["p1", "p2"]
+
+    with open(tmp_path / "csv" / "broad.csv", encoding="utf-8", newline="") as handle:
+        csv_rows = list(csv.DictReader(handle))
+    assert [row["mode"] for row in csv_rows] == ["BROAD", "BROAD"]
+    assert [row["year"] for row in csv_rows] == ["2024", "2025"]


### PR DESCRIPTION
### Motivation
- Remove the runtime dependency on `pandas` for CSV output and rely on the standard library for a smaller, more portable implementation.
- Add automated tests to validate the `collect` script entrypoint and `run_mode` behavior including pagination and output artifacts.

### Description
- Replace the `pandas`-based CSV export with `csv.DictWriter` by adding `import csv` and rewriting `write_csv` to stream rows with `writer.writeheader()` and `writer.writerows()`.
- Remove the `pandas` import line from `slr_meta/collection/semantic_scholar.py`.
- Add `tests/test_collect.py` which provides a `FakeResponse` helper, verifies that `collect` is an alias for the collection module and its `main` is invoked by `collect.py`, and tests `run_mode` pagination, raw JSON merging, and CSV generation by monkeypatching `fetch_with_retries`.

### Testing
- Ran the new test file with `pytest tests/test_collect.py` and the tests for import alias, entrypoint invocation, and `run_mode` pagination/output all passed.
- No other automated test failures were observed when running the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a442f3fbc748330a7dc20479c56b0e0)