### PR TITLE
Adjust year range and simplify intrusion queries in search configs

### DIFF
--- a/config_broad.json
+++ b/config_broad.json
@@ -3,9 +3,9 @@
   "mode": "BROAD",
   "limit": 1000,
   "fieldsOfStudy": "Computer Science",
-  "year": "2022-2026",
+  "year": "2021-2025",
   "fields": "paperId,title,publicationDate,publicationTypes,fieldsOfStudy,influentialCitationCount",
-  "query": "(\"intrusion detection\" | \"intrusion detection system*\" | \"intrusion detection\"~2)",
+  "query": "(\"intrusion\" | \"intrusion detection\" | \"intrusion detection system\")",
   "publicationTypes": "Review",
   "headers": {}
 }

--- a/config_precise.json
+++ b/config_precise.json
@@ -3,9 +3,9 @@
   "mode": "PRECISE",
   "limit": 1000,
   "fieldsOfStudy": "Computer Science",
-  "year": "2022-2026",
+  "year": "2021-2025",
   "fields": "paperId,title,publicationDate,publicationTypes,fieldsOfStudy,influentialCitationCount",
-  "query": "(\"intrusion detection\"~2 | \"intrusion detection system\" | IDS | \"network intrusion*\" | NIDS) + (review | mapping | survey | \"systematic review\" | \"state of the art\" | taxonomy | overview)",
+  "query": "(\"intrusion\" | \"intrusion detection\" | \"intrusion detection system\" | IDS | \"network intrusion\" | NIDS) + (review | mapping | survey | \"systematic review\" | \"state of the art\" | taxonomy | overview)",
   "publicationTypes": "Review",
   "headers": {}
 }


### PR DESCRIPTION
### Motivation
- Align the paper search timeframe with the target window by shifting the year range to `2021-2025`.
- Broaden/simplify query tokenization to use plain terms (remove proximity and wildcard operators) for more consistent matching across the bulk search endpoint.

### Description
- Updated `config_broad.json` and `config_precise.json` to change `"year"` from `"2022-2026"` to `"2021-2025"`.
- Simplified the `"query"` strings in both configs to include plain terms like `"intrusion"`, `"intrusion detection"`, and `"intrusion detection system"`, and removed proximity (`~2`) and wildcard (`*`) operators; the precise config retains `IDS` and `NIDS` and uses `"network intrusion"`.

### Testing
- Ran JSON syntax validation on both config files and the validation succeeded.
- Executed a local config parse/smoke test for the search client that loads these files and the test completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a443421efe08330be1d2d37ebf3febe)