### PR TITLE
Improve select_papers missing dependency error

### DIFF
--- a/select_papers.py
+++ b/select_papers.py
@@ -2,6 +2,15 @@
 """Compatibility CLI/module alias for paper selection and enrichment."""
 import sys
 
+from slr_meta.shared.dependencies import (
+    format_missing_dependency_message,
+    missing_modules,
+)
+
+_missing = missing_modules(["pandas", "openpyxl", "requests"])
+if _missing:
+    sys.exit(format_missing_dependency_message(_missing))
+
 from slr_meta.extraction import workflow as _workflow
 
 sys.modules[__name__] = _workflow

--- a/slr_meta/shared/dependencies.py
+++ b/slr_meta/shared/dependencies.py
@@ -1,0 +1,22 @@
+"""Helpers for validating optional runtime dependencies used by CLI scripts."""
+from __future__ import annotations
+
+import importlib.util
+from collections.abc import Iterable
+
+
+def missing_modules(module_names: Iterable[str]) -> list[str]:
+    """Return the import names that are not available in the current Python environment."""
+    return [name for name in module_names if importlib.util.find_spec(name) is None]
+
+
+def format_missing_dependency_message(
+    missing: Iterable[str], *, command: str = "python -m pip install -r requirements.txt"
+) -> str:
+    """Build an actionable error message for missing runtime dependencies."""
+    missing_list = list(missing)
+    dependency_label = "dependency" if len(missing_list) == 1 else "dependencies"
+    return (
+        f"Missing required Python {dependency_label}: {', '.join(missing_list)}.\n"
+        f"Install the project dependencies with:\n  {command}"
+    )

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,14 @@
+from slr_meta.shared.dependencies import format_missing_dependency_message
+
+
+def test_format_missing_dependency_message_is_actionable_for_single_dependency():
+    message = format_missing_dependency_message(["pandas"])
+
+    assert "Missing required Python dependency: pandas." in message
+    assert "python -m pip install -r requirements.txt" in message
+
+
+def test_format_missing_dependency_message_pluralizes_dependencies():
+    message = format_missing_dependency_message(["pandas", "openpyxl"])
+
+    assert "Missing required Python dependencies: pandas, openpyxl." in message


### PR DESCRIPTION
### Motivation
- Running `select_papers.py` produced a raw `ModuleNotFoundError` when optional runtime packages like `pandas` were not installed, which is unfriendly for CLI users. 
- Provide an early, actionable error that points users to how to install the project dependencies.

### Description
- Add `slr_meta/shared/dependencies.py` with `missing_modules` and `format_missing_dependency_message` helpers to detect missing importable modules and produce an actionable install message.
- Update `select_papers.py` to check for `pandas`, `openpyxl`, and `requests` before importing the extraction workflow and exit with the formatted message when any are missing.
- Add `tests/test_dependencies.py` with tests that validate the error message is actionable and pluralizes correctly.

### Testing
- Ran `pytest -q`, all tests passed (`14 passed in 1.21s`).
- Ran `python select_papers.py --help` to verify the CLI still shows usage/help and exits cleanly when dependencies are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a458528a5a4833089137665d3452f43)